### PR TITLE
extender clase DataLayer

### DIFF
--- a/app/code/community/BitLoop/GoogleTagManager/Block/BodyDataLayer.php
+++ b/app/code/community/BitLoop/GoogleTagManager/Block/BodyDataLayer.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Class BitLoop_GoogleTagManager_Block_DataLayer
+ *
+ * @category BitLoop
+ * @package  BitLoop_Core
+ * @author   Alex Bejan <alex@bitloop.co.uk>
+ * @license  Bitloop License <support@bitloop.co.uk>
+ */
+class BitLoop_GoogleTagManager_Block_BodyDataLayer
+    extends BitLoop_GoogleTagManager_Block_DataLayer
+{
+   
+}


### PR DESCRIPTION
Este archivo solo extiende la clase data layer para poder tener el código de GTM en head y el no-script dentro del body